### PR TITLE
source at pretend phase too

### DIFF
--- a/gcc-switcher
+++ b/gcc-switcher
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-[[ "${EBUILD_PHASE}" != "setup" ]] && return 0
+# we need support for both pretend and setup phases
+[[ "${EBUILD_PHASE}" != "pretend" && \
+    "${EBUILD_PHASE}" != "setup" ]] && return 0
 
 PORT_ETC="/etc/portage"
 


### PR DESCRIPTION
Newest chromium wants gcc >= 5 (not stable yet) and ebuild checks this during both pretend and setup phases.